### PR TITLE
Page Unreal Engine 4

### DIFF
--- a/content/unreal-engine-4.md
+++ b/content/unreal-engine-4.md
@@ -1,0 +1,51 @@
+---
+title: "Portail d'Unreal Engine 4"
+description: "Unreal Engine est un moteur de jeu créer par Epic Games qui permet la création de jeux vidéo et d'applications de très haute qualité."
+onthispage: false
+portail: unreal-engine-4
+menu:
+  general:
+    name: "Unreal Engine 4"
+    parent: "portails"
+    weight: 6
+---
+
+Unreal Engine est un moteur de jeu créer par Epic Games. Il permet la création de jeux vidéo de très haute qualité, et est utilisé dans de nombreux titres, tels que Ark : Survival Evolved, Unreal Tournament 4 ou encore EVE : Valkyrie.
+Gratuit pour une utilisation non-commerciale, il faudra s’acquiter d’une petite redevance auprès d’Epic Games à partir du moment où votre jeu aura rapporté 3000$. Un des principaux atouts de ce moteur est la possibilité de programmer soit en langage C++, soit en utilisant un scripting visuel appelé Blueprint. Ceci permet aux non programmeurs de pouvoir tout de même créer des jeux complexes, sans avoir besoin de passer par la case “Apprentissage d’un langage de programmation”.
+
+L’autre point fort de l’UE 4 est sa qualité graphique. Les très nombreuses options permettent rapidement d’obtenir un résultat agréable à l'oeuil, ou correspondant à vos critères de rendu (cartoon, photo-réaliste, noir & blanc, etc…).
+Enfin, l’intégration des toutes dernières technologies (Réalité Virtuelle, captation de mouvements, etc…) et la portabilité simplifiée vers des plateformes mobiles en font un outils majeur pour les créateurs de jeux vidéo.
+
+Unreal Engine 4 est également utilisé de plus en plus fréquement dans l'industrie, l'architecture ou les VFX, comme par exemple pour la série "The Mandalorian".
+
+## Liste des sections
+
+<div id="index-flex-container">
+    <section>
+      <h4>Apprendre</h4>
+      <ul>
+        <li><a href="https://www.youtube.com/playlist?list=PLqihHB3m2p01eZEHBTshwLXA7npfM5Tic">En vidéo [FR]</a></li>
+        <li><a href="https://www.youtube.com/user/VirtusEdu">En vidéo [EN]</a></li>
+      </ul>
+    </section>
+    <section>
+      <h4>Aller plus loin</h4>
+      <ul>
+        <li><a href="https://www.youtube.com/playlist?list=PLqihHB3m2p03RcY97ry5lImHTvS1Nf5h1">Les matériaux avancés [FR]</a></li>
+        <li><a href="https://www.youtube.com/playlist?list=PLqihHB3m2p00rkgZv9yhKLow1mo5xlf8a">Créer un jeu *Twitch Plays* [FR]</a></li>
+      </ul>
+    </section>
+    <section>
+    	<h4>Liens utiles</h4>
+      <ul>
+        <li><a href="https://www.unrealengine.com/en-US/">Site officiel</a></li>
+        <li><a href="https://docs.unrealengine.com/en-US/index.html">Documentation [EN]</a></li>
+        <li><a href="https://www.unrealengine.com/en-US/onlinelearning-courses">Vidéos officielles [EN]</a></li>
+        <li><a href="https://forums.unrealengine.com/international/europe">Forum Européen</a></li>
+      </ul>
+    </section>
+</div>
+
+## Moteurs similaires
+
+Unreal Engine 4 n'est pas le seul moteur 3D disponible. [Unity]({{< ref "unity.md" >}}) reste une référence, tandis que Godot Engine est la solution libre et Open Source de référence. Il en existe bien d'autres, mais souvent leur communauté n'est pas très importante ou active.


### PR DESCRIPTION
J'ai créé une page pour Unreal Engine 4.
Je n'ai pas inclus toutes mes vidéos, je préfère ne mettre que les plus pertinentes, et proposer d'autres liens externes.
J'ai ajouté des tags [FR] et [EN] pour différencier le contenu francophone de l'anglophone.
Par contre je n'ai pas trouvé où mettre l'image d'en-tête.